### PR TITLE
[Chassis base] Add sfp error event definition

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -433,6 +433,17 @@ class ChassisBase(device_base.DeviceBase):
                   Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
                       indicates that fan 0 has been removed, fan 2
                       has been inserted and sfp 11 has been removed.
+                  specifically for SFP event, besides SFP plug in and plug out,
+                  there are some other error event could be raised from SFP, when 
+                  these error happened, SFP eeprom will not be avalaible, XCVRD shall
+                  stop to read eeprom before SFP recovered from error status.
+                      status='0' SFP removed,
+                      status='1' SFP inserted,
+                      status='2' I2C bus stuck,
+                      status='3' Bad eeprom,
+                      status='4' Unsupported cable,
+                      status='5' High Temperature,
+                      status='6' Bad cable.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Add some SFP error events definition, these events can be handled by XCVRD.
Vendors can new error events if they feel needed, just make sure when adding new some event also should extend the xcvrd to can handle these new events.