### PR TITLE
[CMIS]The get_error_description function should return 'OK' instead of None when there are no errors.

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -3152,6 +3152,6 @@ class CmisApi(XcvrApi):
         if state != CmisCodes.MODULE_STATE[3]:
             return state
 
-        return None
+        return 'OK'
 
     # TODO: other XcvrApi methods

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -3066,7 +3066,7 @@ class TestCmis(object):
         self.api.xcvr_eeprom.read.return_value = 0x10
 
         result = self.api.get_error_description()
-        assert result is None
+        assert result is 'OK'
 
     def test_random_read_fail(self):
         def mock_read_raw(offset, size):


### PR DESCRIPTION
…s no error

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

